### PR TITLE
remove : default for _cameraTarget.material

### DIFF
--- a/__test__/SphericalController.spec.ts
+++ b/__test__/SphericalController.spec.ts
@@ -21,9 +21,12 @@ describe("SphericalController", () => {
 
   test("constructor without target material", () => {
     const mesh = new Mesh();
+    const consoleWarnMock = jest.spyOn(console, "warn").mockImplementation();
     mesh.material = undefined;
     const controller = new SphericalController(new Camera(), mesh);
     expect(controller).toBeTruthy();
+    expect(consoleWarnMock).toBeCalled();
+    consoleWarnMock.mockRestore();
   });
 
   test("clone", () => {

--- a/src/SphericalController.ts
+++ b/src/SphericalController.ts
@@ -52,11 +52,10 @@ export class SphericalController extends EventDispatcher<
     super();
 
     this._cameraTarget = target;
-    this._cameraTarget.material ??= new MeshBasicMaterial({
-      color: 0xff0000,
-      opacity: 0.0,
-      transparent: true,
-    });
+    if (!this._cameraTarget.geometry || !this._cameraTarget.material) {
+      console.warn("No geometry or material for camera target object.");
+    }
+
     this.cameraUpdater = new CameraPositionUpdater(this, camera);
 
     TWEENTicker.start();


### PR DESCRIPTION
related : #50

代わりに警告メッセージを追加。カメラターゲットのジオメトリとマテリアルは、パッケージ利用者側が担保する。

