### PR TITLE
fix : #48

### DIFF
--- a/__test__/SphericalController.initPosition.spec.ts
+++ b/__test__/SphericalController.initPosition.spec.ts
@@ -47,6 +47,4 @@ describe("initPosition", () => {
       new Spherical(Number.MAX_VALUE, Math.PI - EPS, 1000)
     );
   });
-
-  // TODO init関数ではカメラポジションを直接受け取らず、cloneする。
 });

--- a/__test__/SphericalController.initPosition.spec.ts
+++ b/__test__/SphericalController.initPosition.spec.ts
@@ -12,6 +12,18 @@ describe("initPosition", () => {
     );
   });
 
+  test("Arguments of initPosition should not affect cameraPosition.", () => {
+    const controller = new SphericalController(new Camera(), new Mesh());
+    const pos = new Spherical(100, 1, -1);
+    const originalPos = pos.clone();
+
+    controller.initCameraPosition(pos);
+    expect(controller.cloneSphericalPosition()).toStrictEqual(originalPos);
+
+    pos.set(150, 0, 0);
+    expect(controller.cloneSphericalPosition()).toStrictEqual(originalPos);
+  });
+
   test("init camera position and target position", () => {
     const controller = new SphericalController(new Camera(), new Mesh());
     const onUpdate = jest.fn();

--- a/src/SphericalController.ts
+++ b/src/SphericalController.ts
@@ -77,7 +77,7 @@ export class SphericalController extends EventDispatcher<
    * @param targetPos
    */
   public initCameraPosition(pos: Spherical, targetPos?: Vector3): void {
-    this.pos = pos;
+    this.pos.set(pos.radius, pos.phi, pos.theta);
     const lmt = this.limiter;
     lmt.clampPosition(SphericalParamType.PHI, this.pos);
     lmt.clampPosition(SphericalParamType.THETA, this.pos);


### PR DESCRIPTION
initPositionの引数posをcloneする。外部から引数posを変更しても、cameraPositionには影響を与えないことを保証する。