### PR TITLE
Add test for division by zero case in getFirstDuration function

### DIFF
--- a/__test__/SphericalControllerUtil.spec.ts
+++ b/__test__/SphericalControllerUtil.spec.ts
@@ -28,6 +28,10 @@ describe("SphericalControllerUtil", () => {
     expect(getFirstDuration(1, 0, 1.0, -1)).toBe(0.5);
     expect(getFirstDuration(1, 0.5, 1.0, -1)).toBe(0.75);
     expect(getFirstDuration(1, 1.0, 1.0, -1)).toBe(1);
+
+    // Test for division by zero case (when max equals min)
+    expect(getFirstDuration(1, 5, 10, 10)).toBe(0); // max equals min (10 === 10)
+    expect(getFirstDuration(2, -5, -3, -3)).toBe(0); // max equals min with negative values
   });
 
   test("getTweenTheta", () => {

--- a/__test__/SphericalControllerUtil.spec.ts
+++ b/__test__/SphericalControllerUtil.spec.ts
@@ -20,7 +20,7 @@ describe("SphericalControllerUtil", () => {
     expect((target.material as MeshBasicMaterial).opacity).toBe(0.0);
   });
 
-  test("getFirstDuration", () => {
+  test("getFirstDuration (normal range)", () => {
     expect(getFirstDuration(1, 0, 1.0, 0)).toBe(0);
     expect(getFirstDuration(1, 0.5, 1.0, 0)).toBe(0.5);
     expect(getFirstDuration(1, 1.0, 1.0, 0)).toBe(1);
@@ -28,10 +28,12 @@ describe("SphericalControllerUtil", () => {
     expect(getFirstDuration(1, 0, 1.0, -1)).toBe(0.5);
     expect(getFirstDuration(1, 0.5, 1.0, -1)).toBe(0.75);
     expect(getFirstDuration(1, 1.0, 1.0, -1)).toBe(1);
+  });
 
-    // Test for division by zero case (when max equals min)
-    expect(getFirstDuration(1, 5, 10, 10)).toBe(0); // max equals min (10 === 10)
-    expect(getFirstDuration(2, -5, -3, -3)).toBe(0); // max equals min with negative values
+  test("getFirstDuration (max equals min)", () => {
+    // division-by-zero guard
+    expect(getFirstDuration(1, 5, 10, 10)).toBe(0);
+    expect(getFirstDuration(2, -5, -3, -3)).toBe(0);
   });
 
   test("getTweenTheta", () => {


### PR DESCRIPTION
## Description

This PR adds test cases to verify that the `getFirstDuration` function correctly handles the division by zero scenario.

## Changes

- Added test cases to verify that when `max` equals `min` (which would cause a division by zero if not handled properly), the function correctly returns 0.
- Added tests for both positive and negative equal values.

## Testing

All tests pass successfully, confirming that the fix for the division by zero issue is working correctly and will prevent regression in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test cases to cover scenarios where input parameters are equal, ensuring correct handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->