### PR TITLE
fix: remove deprecated lint script and update lint-staged configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "coverage": "npx vitest --coverage --run",
-    "lint": "biome check --write",
     "start:dev": "npm run server & npm run watch:tsc & npm run watch:demo",
     "build": "npm run typedocs & npm run demo",
     "demo": "npm run buildTS && npx @masatomakino/gulptask-demo-page --body '<canvas id=\"webgl-canvas\" width=\"1920\" height=\"1080\"></canvas>' --compileModule es2020",
@@ -79,6 +78,6 @@
     "lib": "esm"
   },
   "lint-staged": {
-    "*.{js,ts,css,md}": "npm run lint"
+    "*.{js,ts,css,md}": "biome check --write"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated lint-staged configuration to run the linting command directly on staged files.
  - Removed the lint script from available npm scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->