### PR TITLE
Improve pre-push hook script execution

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
 npx biome ci .
 npm test


### PR DESCRIPTION
Add shebang and set `-e` in the pre-push hook to enhance script execution reliability.