### PR TITLE
Deprecate SphericalControllerUtil and suggest named exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,9 @@ export * from "./CameraUpdateEvent.js";
 export * from "./CameraPositionUpdater.js";
 export * from "./CameraPositionLimiter.js";
 export * from "./SphericalControllerTween.js";
+
+import * as SphericalControllerUtil from "./SphericalControllerUtil.js";
+/**
+ * @deprecated Use named exports directly from "@masatomakino/threejs-spherical-controls" instead.
+ */
+export { SphericalControllerUtil };


### PR DESCRIPTION
Mark SphericalControllerUtil as deprecated and recommend using named exports directly from the package instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation Notice**
  - Added a deprecated export for SphericalControllerUtil. Users are advised to switch to named exports directly from the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->