### PR TITLE
Migrate from CodeClimate to native GitHub Actions coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,31 @@
+name: "Pull Request Coverage Report and Comment"
+
+on:
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run coverage
+
+      - name: Report Coverage
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     },
     coverage: {
       provider: "istanbul",
-      reporter: ["text", "lcov"],
+      reporter: ["text", "lcov", "json-summary", "json"],
+      reportOnFailure: true,
       include: ["src/**/*.ts"],
     },
   },


### PR DESCRIPTION
## Summary

- Migrate away from CodeClimate dependency to native GitHub Actions coverage reporting
- Add JSON format coverage output for automated PR comments
- Introduce coverage workflow without external service dependencies

## Background

With CodeClimate service changes and potential service discontinuation concerns, this PR introduces a coverage reporting solution that runs entirely within GitHub's infrastructure without requiring external third-party services.

## Changes

### Coverage Configuration (`vitest.config.ts`)
- Add `json-summary` and `json` reporters to enable structured coverage data output
- Add `reportOnFailure: true` to ensure coverage reports are generated even when tests fail
- Maintain existing `text` and `lcov` reporters for local development

### GitHub Actions Workflow (`.github/workflows/coverage.yml`)
- New workflow that runs on every pull request
- Generates coverage reports and automatically comments on PRs
- Uses `davelosert/vitest-coverage-report-action@v2` for native GitHub integration
- No external service dependencies or API keys required

## Benefits

- **No external dependencies**: Eliminates reliance on third-party coverage services
- **Integrated PR feedback**: Coverage information directly in PR comments
- **Cost-free solution**: Runs on GitHub Actions infrastructure
- **Maintenance-free**: No service account management or API key rotation
- **Always available**: Not affected by external service outages or policy changes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a pull-request coverage workflow that runs on PRs, executes tests with coverage, and posts a coverage summary comment; workflow includes concurrency and timeout safeguards.

- Tests
  - Expanded coverage output to include JSON and JSON-summary formats in addition to existing reports.
  - Enabled reporting-on-failure so coverage details are surfaced even when tests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->