### PR TITLE
Fix TypeScript 5.9.2 build errors with skipLibCheck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@masatomakino/release-helper": "^0.2.0",
         "@tweenjs/tween.js": "^25.0.0",
         "@types/three": "^0.178.0",
-        "@types/webxr": "^0.5.19",
         "@vitest/coverage-istanbul": "^3.0.2",
         "browser-sync": "^3.0.2",
         "eventemitter3": "^5.0.1",
@@ -24,7 +23,7 @@
         "lint-staged": "^16.1.0",
         "three": "^0.179.1",
         "typedoc": "^0.28.0",
-        "typescript": "^5.5.4"
+        "typescript": "^5.9.2"
       },
       "peerDependencies": {
         "@masatomakino/raf-ticker": "0.5.3 - 0.6.x",
@@ -8265,9 +8264,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@masatomakino/release-helper": "^0.2.0",
     "@tweenjs/tween.js": "^25.0.0",
     "@types/three": "^0.178.0",
-    "@types/webxr": "^0.5.19",
     "@vitest/coverage-istanbul": "^3.0.2",
     "browser-sync": "^3.0.2",
     "eventemitter3": "^5.0.1",
@@ -49,7 +48,7 @@
     "lint-staged": "^16.1.0",
     "three": "^0.179.1",
     "typedoc": "^0.28.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.9.2"
   },
   "scripts": {
     "prepare": "husky",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     /* Module Resolution Options */
     "moduleResolution": "Bundler",
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "__test__"]


### PR DESCRIPTION
## Summary
- Fix TypeScript 5.9.2 build errors caused by Buffer type definition changes in `@types/node`
- Add `skipLibCheck: true` to tsconfig.json to skip type checking of declaration files
- Remove unused `@types/webxr` dependency

## Problem
PR #375 (Dependabot's TypeScript 5.8.3→5.9.2 upgrade) failed with Buffer type compatibility errors:
```
Interface 'Buffer' incorrectly extends interface 'Uint8Array<ArrayBufferLike>'
```

## Root Cause Analysis
- TypeScript 5.9.2 introduced stricter type checking for Buffer definitions
- `@types/node` comes indirectly from dev tools (vitest, browser-sync, gulptask-demo-page)
- Same configuration works fine with TypeScript 5.8.3 but fails with 5.9.2
- Verified by testing both versions locally

## Solution
Added `"skipLibCheck": true` to tsconfig.json:
- Skips type checking of `.d.ts` files while preserving strict checking of source code
- More maintainable than restricting `types` array to specific packages
- Allows keeping all necessary dev tools without compatibility issues

## Test Results
- ✅ TypeScript compilation successful
- ✅ All tests pass (27/27)
- ✅ Demo generation works
- ✅ Code quality checks pass

## Alternative Considered
- Using `"types": ["three"]` also works but requires maintenance when adding new type packages
- `skipLibCheck` is recommended by TypeScript team for library projects

🤖 Generated with [Claude Code](https://claude.ai/code)