### PR TITLE
Change Dependabot merge strategy to rebase

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.dependency-type == 'direct:development' && steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Changed Dependabot auto-merge workflow to use `--rebase` instead of `--merge`
- This will create a cleaner git history without merge commits for dependency updates

## Test plan
- [ ] Verify the workflow file syntax is correct
- [ ] Wait for next Dependabot PR to confirm rebase behavior works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency PR merging to use a rebase strategy, resulting in a cleaner, linear Git history and fewer merge commits.
  * Improves repository maintenance workflows, making history review, blame, and rollback simpler for maintainers.
  * No changes to product functionality, user experience, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->