### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -1,5 +1,8 @@
 name: build test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/MasatoMakino/threejs-spherical-controls/security/code-scanning/1](https://github.com/MasatoMakino/threejs-spherical-controls/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. Since the jobs only check out code, install dependencies, and run builds/tests, they do not require any write access to repository resources. The minimal sufficient permission is `contents: read`. This block should be added at the top level of the workflow file (before the `jobs:` key) to apply to all jobs in the workflow. No additional dependencies or changes to the steps are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI workflow permissions to read-only for repository contents, enforcing least-privilege access and enhancing security.
  * No changes to pipeline triggers or job steps; build, test, and deployment behaviors remain unchanged.
  * End-user functionality is unaffected; this is internal process hardening.
  * Improves auditability and reduces risk of unintended write operations during CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->