### PR TITLE
Migrate GitHub Pages deployment to official Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,6 +37,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./docs


### PR DESCRIPTION
## Summary

Migrate from peaceiris/actions-gh-pages to GitHub's official deployment actions to improve security and eliminate commit log pollution.

## Changes

- Split workflow into `build-pages` and `deploy-pages` jobs (避けるべき使用例: avoid naming conflict with CI workflow)
- Replace `peaceiris/actions-gh-pages` with `actions/upload-pages-artifact` and `actions/deploy-pages`
- Update permissions from `contents: write` to `contents: read`, `pages: write`, `id-token: write`
- Add concurrency settings to prevent simultaneous deployments
- Add github-pages environment configuration
- Update `actions/setup-node` to v6.0.0
- Pin all actions to commit SHA for security
- Skip artifact upload on non-main branches to avoid storage consumption

## Benefits

- ✅ No branch commits (artifact-based deployment)
- ✅ Reduced permissions (no write access to repository)
- ✅ GitHub official actions only
- ✅ Improved deployment consistency
- ✅ Optimized storage usage (artifacts only created on main branch)

## Storage Considerations

- GitHub Free tier has 500MB storage limit
- Artifacts consume storage during retention period
- PR builds now only verify build success without creating artifacts

## Test plan

- [x] actionlint validation passed
- [ ] Verify build-pages job runs successfully on this PR
- [ ] After merge, verify deploy-pages job deploys to GitHub Pages
- [ ] Confirm no unnecessary artifacts are created on PR builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured GitHub Pages deployment workflow with separate build and deploy jobs for improved clarity and reliability
  * Enhanced build process with explicit dependency installation and artifact upload steps
  * Added conditional deployment targeting the main branch to ensure stable releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->